### PR TITLE
Add close table button to sales view

### DIFF
--- a/RestApp/RestApp/Vistas/Ventas.xaml
+++ b/RestApp/RestApp/Vistas/Ventas.xaml
@@ -114,6 +114,12 @@
                             Clicked="btnenviar_Clicked"
                             StyleClass="ButtonIniciar"
                             CornerRadius="5"/>
+                    <Button Text="Cerrar mesa"
+                            x:Name="btnCerrarMesa"
+                            IsVisible="False"
+                            Clicked="btnCerrarMesa_Clicked"
+                            StyleClass="ButtonTeclado"
+                            CornerRadius="5"/>
                 </StackLayout>
                 
                 

--- a/RestApp/RestApp/Vistas/Ventas.xaml.cs
+++ b/RestApp/RestApp/Vistas/Ventas.xaml.cs
@@ -40,11 +40,13 @@ namespace RestApp.Vistas
             if (idventa > 0)
             {
                 ventagenerada = "VENTA GENERADA";
+                btnCerrarMesa.IsVisible = true;
                 Mostrardetalleventa();
             }
             else
             {
                 ventagenerada = "VENTA NUEVA";
+                btnCerrarMesa.IsVisible = false;
             }
         }
         private void EliVentasIncompMovil()
@@ -83,6 +85,17 @@ namespace RestApp.Vistas
                 EditarEstadoVentasEspera();
                 EditardetalleventaAenviado();
                 await DisplayAlert("Enviado", "Pedido enviado", "OK");
+                await Navigation.PopAsync();
+            }
+        }
+
+        private async void btnCerrarMesa_Clicked(object sender, EventArgs e)
+        {
+            bool confirmacion = await DisplayAlert("Cerrar mesa", "¿Desea cerrar la mesa?", "Sí", "No");
+            if (confirmacion)
+            {
+                eliminarVenta();
+                LiberarMesa();
                 await Navigation.PopAsync();
             }
         }


### PR DESCRIPTION
## Summary
- show new Cerrar mesa button when a sale is active
- handle Cerrar mesa to delete sale, free the table and confirm action

## Testing
- `dotnet build RestApp/RestApp.sln` *(fails: missing Xamarin Android/iOS targets)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d13eb6dc8329bb55e2b1d8ea09a7