### PR TITLE
Persist server IP and update connection handling

### DIFF
--- a/RestApp/RestApp/Servicio/CONEXIONMAESTRA.cs
+++ b/RestApp/RestApp/Servicio/CONEXIONMAESTRA.cs
@@ -4,13 +4,31 @@ using System.Data;
 using System.Data.SqlClient;
 using System.Text;
 using System.IO;
+using Xamarin.Forms;
+
 namespace RestApp.Servicio
 {
    public  class CONEXIONMAESTRA
     {
         public static string ruta = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "connection.txt");
-        public static string text = File.ReadAllText(ruta);
-        public static string conexion = text;
+        static string parte1 = "Data source =";
+        static string parte2 = ";Initial Catalog=BASEBRIRESTCSHARP;Integrated Security=false;User Id=buman;Password=softwarereal";
+        public static string conexion
+        {
+            get
+            {
+                if (Application.Current.Properties.ContainsKey("server_ip"))
+                {
+                    var ip = Application.Current.Properties["server_ip"].ToString();
+                    return parte1 + ip + parte2;
+                }
+                if (File.Exists(ruta))
+                {
+                    return File.ReadAllText(ruta);
+                }
+                return string.Empty;
+            }
+        }
         public static SqlConnection conectar = new SqlConnection(conexion);
 
         public static void abrir()
@@ -29,3 +47,4 @@ namespace RestApp.Servicio
         }
     }
 }
+

--- a/RestApp/RestApp/Vistas/PedidodeIp.xaml.cs
+++ b/RestApp/RestApp/Vistas/PedidodeIp.xaml.cs
@@ -18,6 +18,10 @@ namespace RestApp.Vistas
         public PedidodeIp()
         {
             InitializeComponent();
+            if (Application.Current.Properties.ContainsKey("server_ip"))
+            {
+                Application.Current.MainPage = new NavigationPage(new Login());
+            }
         }
         string ruta;
         string cadena_de_conexion;
@@ -41,7 +45,7 @@ namespace RestApp.Vistas
         {
             if (Idusuario > 0)
             {
-                crear_archivo();
+                await crear_archivo();
                 await DisplayAlert("!Listo!", "Vuelva a abrir la aplicacion", "OK");
                 System.Diagnostics.Process.GetCurrentProcess().CloseMainWindow();
             }
@@ -50,27 +54,28 @@ namespace RestApp.Vistas
                 await DisplayAlert("Sin conexion", "No se logro conectar al servidor", "OK");
             }
         }
-        private void crear_archivo()
+        private async Task crear_archivo()
         {
+            var nuevaIp = txtconexion.Text;
+            if (Application.Current.Properties.ContainsKey("server_ip") &&
+                Application.Current.Properties["server_ip"].ToString() == nuevaIp)
+            {
+                return;
+            }
+
+            Application.Current.Properties["server_ip"] = nuevaIp;
+            await Application.Current.SavePropertiesAsync();
+
             ruta = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "connection.txt");
-            FileInfo fi = new FileInfo(ruta);
-            StreamWriter sw;
             try
             {
-                if (File.Exists(ruta) == false)
-                {
-                    sw = File.CreateText(ruta);
-                    sw.WriteLine(parte1 + txtconexion.Text + parte2);
-                    sw.Flush();
-                    sw.Close();
-                }
-                else if (File.Exists(ruta) == true)
+                if (File.Exists(ruta))
                 {
                     File.Delete(ruta);
-                    sw = File.CreateText(ruta);
-                    sw.WriteLine(parte1 + txtconexion.Text + parte2);
-                    sw.Flush();
-                    sw.Close();
+                }
+                using (var sw = File.CreateText(ruta))
+                {
+                    sw.WriteLine(parte1 + nuevaIp + parte2);
                 }
             }
             catch (Exception)


### PR DESCRIPTION
## Summary
- Skip IP entry when a persisted `server_ip` exists and go straight to login
- Write `server_ip` to app properties and recreate `connection.txt` only when the IP changes
- Build connection strings from the persisted IP with fallback to `connection.txt`

## Testing
- `dotnet build RestApp/RestApp.sln` *(fails: The imported project "Xamarin.Android.CSharp.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d10f441083298867f7fb80cda926